### PR TITLE
Added missing "s" to the router-link for Announcements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
         class="menu"
       >
         <img src="./assets/logo.svg" class="logo" />
-        <router-link tag="div" to="/announcement" class="option">
+        <router-link tag="div" to="/announcements" class="option">
           <img src="./assets/announcement-icon.svg" alt="img" />
           <h3 v-show="menuOpen" class="menu-desc">Announcements</h3>
         </router-link>


### PR DESCRIPTION
Looks like we forgot the "announcement" in the menu link. Caused navigation back to fail.