### PR TITLE
Announcer scheduling

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -108,6 +108,9 @@ export default {
       this.dateContext.date(date);
       this.selectedDate = this.dateContext.clone();
     }
+  },
+  mounted() {
+    this.$emit("update:date", this.selectedDate.format("MM/DD/YYYY"));
   }
 };
 </script>

--- a/src/views/Conversations.vue
+++ b/src/views/Conversations.vue
@@ -174,6 +174,8 @@ export default {
       this.$store.dispatch("deleteConversation", {
         conversation: this.selectedConversation
       });
+      if (this.conversations.length)
+        this.selectedConversation = this.conversations[0];
     }
   },
   mounted() {


### PR DESCRIPTION
**Issue:** the announcer was not scheduling the message if the calendar date was not clicked first. The current date is automatically shown in the calendar, which gives the user the false impression that today's date has already been selected.

**Solution:** When the calendar is mounted (when the scheduler is opened) it emits its update event which sets the current date in the announcer.  The user no longer has to select a date, the time is the only necessary input.

Also, I updated conversations to switch the selected conversation to a new valid discussion when the previously selected conversation is deleted.